### PR TITLE
[API] Add pmemstream_entry_timestamp()

### DIFF
--- a/src/include/libpmemstream.h
+++ b/src/include/libpmemstream.h
@@ -194,6 +194,8 @@ int pmemstream_entry_iterator_next(struct pmemstream_entry_iterator *iterator, s
 
 void pmemstream_entry_iterator_delete(struct pmemstream_entry_iterator **iterator);
 
+uint64_t pmemstream_entry_timestamp(struct pmemstream *stream, struct pmemstream_entry entry);
+
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -313,6 +313,16 @@ size_t pmemstream_entry_length(struct pmemstream *stream, struct pmemstream_entr
 	return span_get_size(&span_entry->span_base);
 }
 
+uint64_t pmemstream_entry_timestamp(struct pmemstream *stream, struct pmemstream_entry entry)
+{
+	int ret = pmemstream_validate_stream_and_offset(stream, entry.offset);
+	if (ret) {
+		return 0;
+	}
+	struct span_entry *span_entry = (struct span_entry *)span_offset_to_span_ptr(&stream->data, entry.offset);
+	return span_entry->timestamp;
+}
+
 int pmemstream_region_runtime_initialize(struct pmemstream *stream, struct pmemstream_region region,
 					 struct pmemstream_region_runtime **region_runtime)
 {

--- a/src/libpmemstream.map
+++ b/src/libpmemstream.map
@@ -15,6 +15,7 @@ LIBPMEMSTREAM_1.0 {
 		pmemstream_entry_iterator_new;
 		pmemstream_entry_iterator_next;
 		pmemstream_entry_length;
+		pmemstream_entry_timestamp;
 		pmemstream_from_map;
 		pmemstream_persisted_timestamp;
 		pmemstream_publish;


### PR DESCRIPTION
This function returns the timestamp assigned to the entry.
